### PR TITLE
feat: Add RenderSchema model and PDF rendering functionality

### DIFF
--- a/backend/services/admin.py
+++ b/backend/services/admin.py
@@ -1,5 +1,5 @@
-from django.contrib import admin
-from .models import Secrets, ServiceCategory, Service, ServiceFormField, ServiceUsageLog, HTTPStatusCode
+from django.contrib import admin, messages
+from .models import Secrets, ServiceCategory, Service, ServiceFormField, ServiceUsageLog, HTTPStatusCode, RenderSchema
 from django.utils.safestring import mark_safe
 from django import forms
 from django_ckeditor_5.widgets import CKEditor5Widget
@@ -41,7 +41,7 @@ class ServiceAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', 'category', 'api_url','price_per_hit', 'is_active')
     search_fields = ('name', 'api_url')
     list_filter = ('category', 'is_active', 'api_method')
-    ordering = ('category__name', 'name')
+    ordering = ('-created_at',)
     autocomplete_fields = ['secret', 'category']
 
 
@@ -164,3 +164,347 @@ class ServiceUsageLogAdmin(ExportMixin, admin.ModelAdmin):
         return status_text  # fallback for other statuses
 
     colored_status.short_description = "Status"
+
+
+    
+@admin.register(RenderSchema)
+class RenderSchemaAdmin(admin.ModelAdmin):
+    list_display = ("id", "service", "created_at", "updated_at")
+    search_fields = ("service__slug", "service__name")
+    readonly_fields = ("created_at", "updated_at", "schema_guide_display")
+    actions = ["validate_spec"]
+    fieldsets = (
+        (None, {
+            "fields": ("service", "spec", "created_at", "updated_at"),
+        }),
+        ("Schema Authoring Guide", {
+            "fields": ("schema_guide_display",),
+            "classes": ("collapse",),
+        }),
+    )
+
+    def validate_spec(self, request, queryset):
+        ok = 0
+        for schema in queryset:
+            try:
+                schema.full_clean()
+                ok += 1
+            except Exception as e:
+                self.message_user(request, f"{schema} failed: {e}", level=messages.ERROR)
+        if ok:
+            self.message_user(request, f"Validated {ok} schema(s) successfully.", level=messages.SUCCESS)
+    validate_spec.short_description = "Validate selected schema specs"
+
+    def schema_guide_display(self, obj=None):
+        return mark_safe("""
+<style>
+.render-guide {
+    font-family: 'Segoe UI', Roboto, Arial, sans-serif;
+    line-height: 1.5;
+    color: #333;
+}
+
+.render-guide code, 
+.render-guide pre {
+    font-size: 13px;
+    background: #f4f4f4;
+    border-radius: 4px;
+    padding: 2px 6px;
+}
+
+.render-guide pre {
+    padding: 10px;
+    overflow-x: auto;
+    border: 1px solid #ddd;
+}
+
+.render-guide h3 {
+    margin: 12px 0 8px;
+    font-size: 1.1em;
+    color: #222;
+    border-bottom: 2px solid #eee;
+    padding-bottom: 3px;
+}
+
+.render-guide h4 {
+    margin: 10px 0 6px;
+    font-size: 1em;
+    color: #444;
+}
+
+.render-guide ul {
+    margin: 6px 0 10px 20px;
+}
+
+.render-guide li {
+    margin-bottom: 4px;
+}
+
+.render-guide details {
+    margin: 8px 0 10px;
+}
+
+.render-guide summary {
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.render-guide .box {
+    padding: 12px;
+    background: #fdfdfd;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+</style>
+
+<div class="render-guide box">
+    <h3>Schema Structure</h3>
+    <p><code>spec</code> is a JSON object that defines how an API response is normalized and rendered.</p>
+
+    <h4>Top-level keys</h4>
+    <ul>
+        <li><code>service</code> (string) – Identifier; if omitted it is set to the Service's <code>slug</code>.</li>
+        <li><code>map</code> (object) – Maps friendly variable names to JSON paths in the raw response.</li>
+        <li><code>header</code> (object) – Two items: <code>left</code> and <code>right</code> to show at the top.</li>
+        <li><code>sections</code> (array) – Array of sections, each with a <code>title</code> and <code>items</code>.</li>
+        <li><code>security</code> (object) – Optional masking and redaction of sensitive values.</li>
+        <li><code>formatters</code> (object) – Optional reusable formatters used by items and security rules.</li>
+    </ul>
+
+    <h4>map</h4>
+    <p>Define variables for use in <code>header</code> and <code>sections</code>. Supports dotted paths and fallback with <code>||</code>.</p>
+<pre>{
+  "map": {
+    "owner": "result.data.owner",
+    "reg_no": "result.data.regNo",
+    "name": "result.fname || result.full_name"
+  }
+}</pre>
+
+    <h4>header</h4>
+    <p>Two blocks: <code>left</code> and <code>right</code>. Each is an item with:</p>
+    <ul>
+        <li><code>type</code>: <code>"text"</code> or <code>"kv"</code></li>
+        <li><code>label</code>: Label text (for <code>kv</code>)</li>
+        <li><code>source</code>: A variable from <code>map</code></li>
+        <li><code>bold</code>, <code>size</code>: Optional typography for <code>text</code></li>
+        <li><code>format</code>: Optional formatter name</li>
+    </ul>
+<pre>{
+  "header": {
+    "left":  { "type": "text", "label": "Owner", "source": "owner", "bold": true, "size": 16 },
+    "right": { "type": "kv",   "label": "Registration No.", "source": "reg_no", "align": "right" }
+  }
+}</pre>
+
+    <h4>sections</h4>
+    <p>Each section has a <code>title</code> and an <code>items</code> array.</p>
+    <p>Supported item types:</p>
+    <ul>
+        <li><code>kv</code> – <code>{"type":"kv","label":"Status","source":"status","format":"yes_no"}</code></li>
+        <li><code>text</code> – <code>{"type":"text","label":"Note","source":"note"}</code></li>
+        <li><code>address</code> – <code>{"type":"address","source":"address"}</code> (expects an object with standard address keys)</li>
+        <li><code>table</code> – <code>{"type":"table","source":"rows_var","columns":[{"key":"...","title":"..."}],"empty":"No data"}</code></li>
+    </ul>
+<pre>{
+  "sections": [
+    {
+      "title": "Vehicle Summary",
+      "items": [
+        {"type":"kv","label":"Status","source":"status"},
+        {"type":"kv","label":"Commercial","source":"is_commercial","format":"yes_no"}
+      ]
+    }
+  ]
+}</pre>
+
+    <h4>security</h4>
+    <p><code>mask</code> modifies values in-place using a formatter. <code>redact</code> removes keys entirely from the normalized context.</p>
+<pre>{
+  "security": {
+    "mask":   [{ "path": "pan", "format": "mask_pan" }],
+    "redact": ["mobile_number"]
+  }
+}</pre>
+
+    <h4>formatters</h4>
+    <ul>
+        <li><code>mask</code> – args: <code>{"visible_last":4,"char":"X"}</code></li>
+        <li><code>yes_no</code> – renders booleans as Yes/No</li>
+        <li><code>currency_inr</code> – formats numbers as INR (e.g., ₹12,345)</li>
+    </ul>
+<pre>{
+  "formatters": {
+    "mask_pan": { "fn": "mask", "args": {"visible_last": 4} },
+    "yes_no":   { "fn": "yes_no" }
+  }
+}</pre>
+
+    <details>
+      <summary>Example: RC Lookup</summary>
+<pre>{
+  "service": "rc-lookup",
+  "map": {
+    "owner": "result.data.owner",
+    "owner_father": "result.data.ownerFatherName",
+    "reg_no": "result.data.regNo",
+    "status": "result.data.status",
+    "status_as_on": "result.data.statusAsOn",
+    "type": "result.data.type",
+    "class": "result.data.class",
+    "model": "result.data.model",
+    "manufacturer": "result.data.vehicleManufacturerName",
+    "manuf_month_year": "result.data.vehicleManufacturingMonthYear",
+    "body_type": "result.data.bodyType",
+    "color": "result.data.vehicleColour",
+    "engine_no": "result.data.engine",
+    "chassis_no": "result.data.chassis",
+    "cubic_capacity": "result.data.vehicleCubicCapacity",
+    "cylinders": "result.data.vehicleCylindersNo",
+    "seat_capacity": "result.data.vehicleSeatCapacity",
+    "standing_capacity": "result.data.vehicleStandingCapacity",
+    "sleeper_capacity": "result.data.vehicleSleeperCapacity",
+    "unladen_weight": "result.data.unladenWeight",
+    "gross_vehicle_weight": "result.data.grossVehicleWeight",
+    "wheelbase": "result.data.wheelbase",
+    "norms_type": "result.data.normsType",
+    "vehicle_category": "result.data.vehicleCategory",
+    "is_commercial": "result.data.isCommercial",
+    "reg_date": "result.data.regDate",
+    "rc_expiry_date": "result.data.rcExpiryDate",
+    "insurance_company": "result.data.vehicleInsuranceCompanyName",
+    "insurance_policy_no": "result.data.vehicleInsurancePolicyNumber",
+    "insurance_upto": "result.data.vehicleInsuranceUpto",
+    "pucc_number": "result.data.puccNumber",
+    "pucc_upto": "result.data.puccUpto",
+    "tax_upto": "result.data.vehicleTaxUpto",
+    "blacklist_status": "result.data.blacklistStatus",
+    "blacklist_details": "result.data.blacklistDetails",
+    "financed": "result.data.financed",
+    "reg_authority": "result.data.regAuthority",
+    "present_address": "result.data.presentAddress",
+    "permanent_address": "result.data.permanentAddress",
+    "db_result": "result.data.dbResult",
+    "partial_data": "result.data.partialData",
+    "mobile_number": "result.data.mobileNumber"
+  },
+  "header": {
+    "left":  {"type": "text", "label": "Owner", "source": "owner", "bold": true, "size": 16},
+    "right": {"type": "kv", "label": "Registration No.", "source": "reg_no", "align": "right"}
+  },
+  "sections": [
+    {
+      "title": "Vehicle Summary",
+      "items": [
+        {"type": "kv", "label": "Status", "source": "status"},
+        {"type": "kv", "label": "Status As On", "source": "status_as_on"},
+        {"type": "kv", "label": "Class", "source": "class"},
+        {"type": "kv", "label": "Type", "source": "type"},
+        {"type": "kv", "label": "Model", "source": "model"},
+        {"type": "kv", "label": "Manufacturer", "source": "manufacturer"},
+        {"type": "kv", "label": "Manufactured (MM/YY)", "source": "manuf_month_year"},
+        {"type": "kv", "label": "Body Type", "source": "body_type"},
+        {"type": "kv", "label": "Colour", "source": "color"},
+        {"type": "kv", "label": "Registration Authority", "source": "reg_authority"}
+      ]
+    },
+    {
+      "title": "Technical Details",
+      "items": [
+        {"type": "kv", "label": "Engine No.", "source": "engine_no"},
+        {"type": "kv", "label": "Chassis No.", "source": "chassis_no"},
+        {"type": "kv", "label": "Cubic Capacity", "source": "cubic_capacity"},
+        {"type": "kv", "label": "Cylinders", "source": "cylinders"},
+        {"type": "kv", "label": "Seat Capacity", "source": "seat_capacity"},
+        {"type": "kv", "label": "Standing Capacity", "source": "standing_capacity"},
+        {"type": "kv", "label": "Sleeper Capacity", "source": "sleeper_capacity"},
+        {"type": "kv", "label": "Unladen Weight", "source": "unladen_weight"},
+        {"type": "kv", "label": "Gross Vehicle Weight", "source": "gross_vehicle_weight"},
+        {"type": "kv", "label": "Wheelbase", "source": "wheelbase"},
+        {"type": "kv", "label": "Emission Norms", "source": "norms_type"},
+        {"type": "kv", "label": "Vehicle Category", "source": "vehicle_category"},
+        {"type": "kv", "label": "Commercial", "source": "is_commercial", "format": "yes_no"}
+      ]
+    },
+    {
+      "title": "Validity & Compliance",
+      "items": [
+        {"type": "kv", "label": "Registration Date", "source": "reg_date"},
+        {"type": "kv", "label": "RC Expiry", "source": "rc_expiry_date"},
+        {"type": "kv", "label": "Insurance Company", "source": "insurance_company"},
+        {"type": "kv", "label": "Insurance Policy No.", "source": "insurance_policy_no"},
+        {"type": "kv", "label": "Insurance Valid Upto", "source": "insurance_upto"},
+        {"type": "kv", "label": "PUCC Number", "source": "pucc_number"},
+        {"type": "kv", "label": "PUCC Valid Upto", "source": "pucc_upto"},
+        {"type": "kv", "label": "Road Tax Upto", "source": "tax_upto"}
+      ]
+    },
+    {
+      "title": "Ownership & Risk",
+      "items": [
+        {"type": "kv", "label": "Owner (Father's Name)", "source": "owner_father"},
+        {"type": "kv", "label": "Blacklist Status", "source": "blacklist_status", "format": "yes_no"},
+        {"type": "kv", "label": "Financed", "source": "financed"},
+        {"type": "kv", "label": "Database Verified", "source": "db_result", "format": "yes_no"},
+        {"type": "kv", "label": "Partial Data", "source": "partial_data", "format": "yes_no"}
+      ]
+    },
+    {
+      "title": "Contact & Addresses",
+      "items": [
+        {"type": "kv", "label": "Mobile Number", "source": "mobile_number"},
+        {"type": "kv", "label": "Present Address", "source": "present_address"},
+        {"type": "kv", "label": "Permanent Address", "source": "permanent_address"}
+      ]
+    }
+  ],
+  "security": { "mask": [], "redact": [] },
+  "formatters": { "yes_no": { "fn": "yes_no" } }
+}</pre>
+    </details>
+
+    <details>
+      <summary>Example: PAN Lookup</summary>
+<pre>{
+  "service": "pan-lookup",
+  "map": {
+    "pan": "result.pan_number",
+    "name": "result.fname || result.full_name",
+    "address": "result.address",
+    "proprietor_rows": "result.is_sole_proprietor.info"
+  },
+  "header": {
+    "left":  { "type": "text", "label": "Full Name", "source": "name", "bold": true, "size": 16 },
+    "right": { "type": "kv", "label": "PAN", "source": "pan", "format": "mask_pan", "align": "right" }
+  },
+  "sections": [
+    {
+      "title": "Identity",
+      "items": [
+        { "type": "address", "source": "address" }
+      ]
+    },
+    {
+      "title": "Proprietor Details",
+      "items": [
+        {
+          "type": "table",
+          "source": "proprietor_rows",
+          "empty": "No data",
+          "columns": [
+            { "key": "gst", "title": "GST" },
+            { "key": "status", "title": "Status" },
+            { "key": "aggregate_turn_over", "title": "Turnover" }
+          ]
+        }
+      ]
+    }
+  ],
+  "security": { "mask": [{ "path": "pan", "format": "mask_pan" }], "redact": [] },
+  "formatters": { "mask_pan": { "fn": "mask", "args": { "visible_last": 4 } } }
+}</pre>
+    </details>
+</div>
+        """)
+    schema_guide_display.short_description = "How to write the schema"

--- a/backend/services/pdf_renderer.py
+++ b/backend/services/pdf_renderer.py
@@ -1,0 +1,395 @@
+from io import BytesIO
+import os
+from django.conf import settings
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+from reportlab.lib.units import cm
+from reportlab.lib import colors
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.platypus import Table, TableStyle, Paragraph
+from reportlab.lib.utils import ImageReader
+
+
+def _fmt_value(v):
+    if v is True:
+        return "Yes"
+    if v is False:
+        return "No"
+    if v is None:
+        return "Not Available"
+    if isinstance(v, str):
+        s = v.strip()
+        return s if s else "Not Available"
+    return str(v)
+
+
+def _draw_wrapped_text(p, x, y, text, width, font_name="Helvetica", font_size=11, leading=14):
+    if text is None:
+        text = "Not Available"
+    text = _fmt_value(text)
+    p.setFont(font_name, font_size)
+    words = str(text).split()
+    line = []
+    space_w = p.stringWidth(" ", font_name, font_size)
+    cur_w = 0
+    yy = y
+    for w in words:
+        ww = p.stringWidth(w, font_name, font_size)
+        if cur_w + ww + (space_w if line else 0) > width:
+            p.drawString(x, yy, " ".join(line))
+            yy -= leading
+            line = [w]
+            cur_w = ww
+        else:
+            if line:
+                cur_w += space_w + ww
+                line.append(w)
+            else:
+                cur_w = ww
+                line = [w]
+    if line:
+        p.drawString(x, yy, " ".join(line))
+        yy -= leading
+    return yy
+
+
+def _draw_kv(p, x, y, label, value, label_w=3*cm, width=16*cm, font_size=11, leading=14, pad=6):
+    # Measure the actual label width and ensure value starts after it (plus pad)
+    p.setFont("Helvetica-Bold", font_size)
+    label_txt = f"{label}:"
+    p.drawString(x, y, label_txt)
+
+    measured = p.stringWidth(label_txt, "Helvetica-Bold", font_size)
+    value_x = x + max(label_w, measured + pad)
+
+    p.setFont("Helvetica", font_size)
+    return _draw_wrapped_text(p, value_x, y, _fmt_value(value), width - (value_x - x), "Helvetica", font_size, leading)
+
+
+# def _draw_table(p, x, y, columns, rows, max_width=18*cm, font_size=10):
+#     styles = getSampleStyleSheet()
+#     cell_style = ParagraphStyle(
+#         "cell",
+#         parent=styles["BodyText"],
+#         fontName="Helvetica",
+#         fontSize=font_size,
+#         leading=font_size + 3,
+#     )
+#     header_style = ParagraphStyle(
+#         "header",
+#         parent=styles["BodyText"],
+#         fontName="Helvetica-Bold",
+#         fontSize=font_size + 0.5,
+#         leading=font_size + 3,
+#     )
+
+#     col_keys = [c["key"] for c in columns]
+#     col_titles = [c.get("title") or c["key"] for c in columns]
+#     num_cols = max(1, len(columns))
+#     col_widths = [max_width / num_cols] * num_cols
+
+#     data = [[Paragraph(str(t), header_style) for t in col_titles]]
+#     for row in rows:
+#         data.append([Paragraph(_fmt_value(row.get(k)), cell_style) for k in col_keys])
+
+#     tbl = Table(data, colWidths=col_widths, repeatRows=1, hAlign="LEFT")
+#     ts = TableStyle([
+#         ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#F2F2F5")),
+#         ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+#         ("LINEABOVE", (0, 0), (-1, 0), 0.6, colors.grey),
+#         ("LINEBELOW", (0, 0), (-1, 0), 0.6, colors.grey),
+#         ("INNERGRID", (0, 0), (-1, -1), 0.25, colors.HexColor("#DDDEE3")),
+#         ("BOX", (0, 0), (-1, -1), 0.25, colors.HexColor("#DDDEE3")),
+#         ("VALIGN", (0, 0), (-1, -1), "TOP"),
+#         ("LEFTPADDING", (0, 0), (-1, -1), 6),
+#         ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+#         ("TOPPADDING", (0, 0), (-1, -1), 5),
+#         ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+#     ])
+
+#     # Alternate row shading (skip header row)
+#     for r in range(1, len(data)):
+#         if r % 2 == 0:
+#             ts.add("BACKGROUND", (0, r), (-1, r), colors.whitesmoke)
+
+#     # Align numeric columns right
+#     for ci, key in enumerate(col_keys):
+#         numeric = True
+#         for r in rows:
+#             v = r.get(key)
+#             if isinstance(v, bool) or v is None:
+#                 continue
+#             if not isinstance(v, (int, float)):
+#                 numeric = False
+#                 break
+#         if numeric:
+#             ts.add("ALIGN", (ci, 1), (ci, -1), "RIGHT")
+
+#     tbl.setStyle(ts)
+
+#     # Pagination-aware drawing
+#     tw, th = tbl.wrapOn(p, max_width, 0)
+#     bottom_y = y - th
+#     page_w, page_h = A4
+#     bottom_margin = 3 * cm
+#     if bottom_y < bottom_margin:
+#         p.showPage()
+#         y = page_h - 2 * cm
+#         bottom_y = y - th
+
+#     tbl.drawOn(p, x, bottom_y)
+#     return bottom_y - 0.2 * cm
+
+PALETTE = {
+    "header_bg": colors.HexColor("#111827"),
+    "header_text": colors.white,
+    "row_alt": colors.Color(0.985, 0.987, 0.99),
+    "grid": colors.HexColor("#D5D5D5"),
+}
+
+def _fmt_cell_html(v):
+    s = _fmt_value(v)
+    if s == "Yes":
+        return '<font color="#16a34a"><b>Yes</b></font>'
+    if s == "No":
+        return '<font color="#dc2626"><b>No</b></font>'
+    if s == "Not Available":
+        return '<font color="#6b7280">Not Available</font>'
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+def _draw_table(p, x, y, columns, rows, max_width=18*cm, font_size=10):
+    styles = getSampleStyleSheet()
+    cell_style = ParagraphStyle(
+        "cell",
+        parent=styles["BodyText"],
+        fontName="Helvetica",
+        fontSize=font_size,
+        leading=font_size + 3,
+        spaceAfter=0,
+        spaceBefore=0,
+    )
+    header_style = ParagraphStyle(
+        "header",
+        parent=styles["BodyText"],
+        fontName="Helvetica-Bold",
+        fontSize=font_size + 0.5,
+        leading=font_size + 4,
+        textColor=PALETTE["header_text"],
+        spaceAfter=0,
+        spaceBefore=0,
+    )
+
+    col_keys = [c["key"] for c in columns]
+    col_titles = [c.get("title") or c["key"] for c in columns]
+    num_cols = max(1, len(columns))
+
+    if any(isinstance(c.get("width"), (int, float)) for c in columns):
+        raw = [float(c.get("width", 0)) for c in columns]
+        s = sum(raw) or 1.0
+        col_widths = [max_width * (w / s) if w > 0 else max_width / num_cols for w in raw]
+    else:
+        col_widths = [max_width / num_cols] * num_cols
+
+    data = [[Paragraph(str(t), header_style) for t in col_titles]]
+    for row in rows:
+        data.append([Paragraph(_fmt_cell_html(row.get(k)), cell_style) for k in col_keys])
+
+    tbl = Table(data, colWidths=col_widths, repeatRows=1, hAlign="LEFT")
+    ts = TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), PALETTE["header_bg"]),
+        ("TEXTCOLOR", (0, 0), (-1, 0), PALETTE["header_text"]),
+        ("LINEABOVE", (0, 0), (-1, 0), 0.6, PALETTE["header_bg"]),
+        ("LINEBELOW", (0, 0), (-1, 0), 0.6, PALETTE["header_bg"]),
+        ("INNERGRID", (0, 1), (-1, -1), 0.25, PALETTE["grid"]),
+        ("BOX", (0, 0), (-1, -1), 0.4, PALETTE["grid"]),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 7),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 7),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+    ])
+
+    for r in range(1, len(data)):
+        if r % 2 == 0:
+            ts.add("BACKGROUND", (0, r), (-1, r), PALETTE["row_alt"])
+
+    for ci, col in enumerate(columns):
+        align = (col.get("align") or "").lower()
+        if align in ("left", "center", "right"):
+            ts.add("ALIGN", (ci, 1), (ci, -1), align.upper())
+        else:
+            numeric = True
+            for r in rows:
+                v = r.get(col["key"])
+                if isinstance(v, bool) or v is None:
+                    continue
+                if not isinstance(v, (int, float)):
+                    numeric = False
+                    break
+            if numeric:
+                ts.add("ALIGN", (ci, 1), (ci, -1), "RIGHT")
+
+    tbl.setStyle(ts)
+
+    tw, th = tbl.wrapOn(p, max_width, 0)
+    bottom_y = y - th
+    page_w, page_h = A4
+    bottom_margin = 3 * cm
+    if bottom_y < bottom_margin:
+        p.showPage()
+        y = page_h - 2 * cm
+        bottom_y = y - th
+
+    tbl.drawOn(p, x, bottom_y)
+    return bottom_y - 0.25 * cm
+
+
+
+def _draw_logo_top_left(p, x_left, y_top, max_width_cm=3.0, max_height_cm=1.5):
+    logo_path = os.path.join(settings.BASE_DIR, "static", "branding", "logo.png")
+    if not os.path.exists(logo_path):
+        return y_top
+    try:
+        img = ImageReader(logo_path)
+        iw, ih = img.getSize()
+        max_w = max_width_cm * cm
+        max_h = max_height_cm * cm
+        scale = min(max_w / iw, max_h / ih)
+        w = iw * scale
+        h = ih * scale
+        # drawImage places bottom-left at (x, y). We want the logo to sit below the top baseline.
+        p.drawImage(img, x_left, y_top - h, width=w, height=h, preserveAspectRatio=True, mask='auto')
+        return y_top - h - (1.5 * cm)  # small gap below logo
+    except Exception:
+        return y_top
+    
+    
+def _draw_watermark(p, page_w, page_h):
+#     p.saveState()
+#     p.setFillColorRGB(0.85, 0.85, 0.85)  # light grey
+#     p.setFont("Helvetica-Bold", 50)
+#     p.translate(page_w / 2, page_h / 2)
+#     p.rotate(45)
+#     p.drawCentredString(0, 0, "DealerADO")
+#     p.restoreState()
+    
+    logo_path = os.path.join(settings.BASE_DIR, "static", "branding", "logo.png")
+    if not os.path.exists(logo_path):
+        return
+    from PIL import Image, ImageEnhance
+    img_pil = Image.open(logo_path).convert("RGBA")  # Keep alpha channel
+    
+    # Convert to grayscale (L), then back to RGBA
+    img_gray = img_pil.convert("L").convert("RGBA")
+    
+    # Reduce opacity
+    alpha = img_gray.split()[3]  # Get the alpha channel
+    alpha = ImageEnhance.Brightness(alpha).enhance(0.3)  # 0.0 = fully transparent, 1.0 = full opacity
+    img_gray.putalpha(alpha)
+    img = ImageReader(img_gray)
+    iw, ih = img.getSize()
+    max_size = 8 * cm
+    scale = min(max_size / iw, max_size / ih)
+    w = iw * scale
+    h = ih * scale
+
+    p.saveState()
+    p.translate(page_w / 2, page_h / 2)
+    p.rotate(30)
+    p.drawImage(img, -w/2, -h/2, width=w, height=h, mask='auto')
+    p.restoreState()
+
+
+def render_ast_to_pdf(service_title: str, ast: dict, user_label: str = "") -> bytes:
+    buf = BytesIO()
+    p = canvas.Canvas(buf, pagesize=A4)
+    page_w, page_h = A4
+    
+    _draw_watermark(p, page_w, page_h)
+
+    x_margin = 2 * cm
+    y = page_h - 2 * cm
+
+    # Logo top-left
+    y = _draw_logo_top_left(p, x_margin, y)
+
+    # Title on same line height (to the right of logo top area) – simplest: draw below logo
+    p.setFont("Helvetica-Bold", 16)
+    p.drawString(x_margin, y, service_title)
+    if user_label:
+        p.setFont("Helvetica", 10)
+        p.drawRightString(page_w - x_margin, y, user_label)
+    y -= 0.8 * cm
+
+    # Header left/right
+    header = ast.get("header", {})
+    left = header.get("left", {})
+    right = header.get("right", {})
+
+    if left:
+        label = left.get("label") or ""
+        value = left.get("value")
+        p.setFont("Helvetica-Bold", 12 if left.get("bold") else 11)
+        y = _draw_kv(p, x_margin, y, label, value, label_w=2.8 * cm, width=17 * cm)
+    if right:
+        label = right.get("label") or ""
+        value = right.get("value")
+        p.setFont("Helvetica-Bold", 11)
+        p.drawRightString(page_w - x_margin, y + 14, f"{label}: {_fmt_value(value)}")
+
+    # Divider
+    y -= 0.2 * cm
+    p.setStrokeColor(colors.lightgrey)
+    p.line(x_margin, y, page_w - x_margin, y)
+    y -= 1 * cm
+
+    # Sections
+    for section in ast.get("sections", []):
+        title = section.get("title") or ""
+        if title:
+            p.setFont("Helvetica-Bold", 14)
+            p.drawString(x_margin, y, title)
+            y -= 0.8 * cm
+
+        for item in section.get("items", []):
+            t = item.get("type")
+            if t in ("kv", "text"):
+                label = item.get("label") or ""
+                value = item.get("value")
+                y = _draw_kv(p, x_margin, y, label, value, label_w=5 * cm, width=30 * cm)
+                y -= 0.12 * cm
+            elif t == "address":
+                addr = item.get("value") or {}
+                parts = [addr.get(k) for k in ["line_1", "line_2", "street", "city", "state", "pincode", "zip", "country"]]
+                parts = [str(v) for v in parts if v not in (None, "", [])]
+                comp = ", ".join(parts) if parts else "Not Available"
+                y = _draw_kv(p, x_margin, y, "Address", comp, label_w=3.2 * cm, width=17 * cm)
+                y -= 0.12 * cm
+            elif t == "table":
+                cols = item.get("columns") or []
+                rows = item.get("rows") or []
+                
+                if rows:
+                    y = _draw_table(p, x_margin, y, cols, rows, max_width=17 * cm)
+                else:
+                    col_keys = [c.get("key") for c in cols]
+                    placeholder = {k: "Not Available" for k in col_keys}
+                    rows = [placeholder]
+                    y = _draw_table(p, x_margin, y, cols, rows, max_width=17 * cm)
+
+            if y < 3 * cm:
+                p.showPage()
+                y = page_h - 2 * cm
+
+        # small gap between sections
+        y -= 0.35 * cm
+        if section != ast["sections"][-1]:
+            p.setStrokeColor(colors.lightgrey)
+            p.setLineWidth(0.5)
+            p.line(x_margin, y, page_w - x_margin, y)
+            y -= 0.95 * cm
+
+    p.showPage()
+    _draw_watermark(p, page_w, page_h)
+    p.save()
+    return buf.getvalue()

--- a/backend/services/rendering.py
+++ b/backend/services/rendering.py
@@ -1,0 +1,211 @@
+from typing import Any, Dict, List, Optional
+from .models import Service
+
+
+def deep_get(obj: Any, path: str):
+    cur = obj
+    for part in path.split("."):
+        if isinstance(cur, list):
+            try:
+                idx = int(part)
+                cur = cur[idx]
+            except Exception:
+                return None
+        else:
+            cur = cur.get(part) if isinstance(cur, dict) else None
+        if cur is None:
+            return None
+    return cur
+
+
+def deep_set(obj: Dict[str, Any], path: str, value: Any):
+    parts = path.split(".")
+    cur = obj
+    for i, part in enumerate(parts):
+        last = i == len(parts) - 1
+        if last:
+            if isinstance(cur, dict):
+                cur[part] = value
+            else:
+                return
+        else:
+            if isinstance(cur, dict):
+                if part not in cur or not isinstance(cur[part], dict):
+                    cur[part] = {}
+                cur = cur[part]
+            else:
+                return
+
+
+def deep_delete(obj: Dict[str, Any], path: str):
+    parts = path.split(".")
+    cur = obj
+    for i, part in enumerate(parts):
+        last = i == len(parts) - 1
+        if last:
+            if isinstance(cur, dict) and part in cur:
+                del cur[part]
+            return
+        else:
+            if isinstance(cur, dict):
+                cur = cur.get(part)
+            else:
+                return
+        if cur is None:
+            return
+
+
+def coalesce_expr(expr: str, raw: Dict[str, Any]):
+    parts = [p.strip() for p in expr.split("||")]
+    for p in parts:
+        v = deep_get(raw, p) if "." in p else raw.get(p)
+        if v not in (None, ""):
+            return v
+    return None
+
+
+def normalize(raw: Dict[str, Any], mapping: Dict[str, str]) -> Dict[str, Any]:
+    ctx = {}
+    for k, expr in mapping.items():
+        if isinstance(expr, str) and "||" in expr:
+            ctx[k] = coalesce_expr(expr, raw)
+        else:
+            ctx[k] = deep_get(raw, expr) if isinstance(expr, str) and "." in expr else raw.get(expr)
+    return ctx
+
+
+def fmt_mask(value, args: Dict[str, Any]):
+    if not value:
+        return value
+    s = str(value)
+    keep = int(args.get("visible_last", 4))
+    char = str(args.get("char", "X"))
+    return (char * max(0, len(s) - keep)) + s[-keep:]
+
+
+def fmt_yes_no(value, args: Dict[str, Any]):
+    return "Yes" if bool(value) else "No"
+
+
+def fmt_currency_inr(value, args: Dict[str, Any]):
+    if isinstance(value, (int, float)):
+        return f"₹{value:,}"
+    return value
+
+
+FORMATTERS = {
+    "mask": fmt_mask,
+    "yes_no": fmt_yes_no,
+    "currency_inr": fmt_currency_inr
+}
+
+
+def apply_format(value, fmt_name: Optional[str], schema_formatters: Dict[str, Dict[str, Any]]):
+    if not fmt_name:
+        return value
+    fmt_def = schema_formatters.get(fmt_name)
+    if not fmt_def:
+        return value
+    fn = FORMATTERS.get(fmt_def.get("fn"))
+    if not fn:
+        return value
+    return fn(value, fmt_def.get("args", {}))
+
+
+def apply_security_on_ctx(ctx: Dict[str, Any], spec: Dict[str, Any]):
+    sec = spec.get("security") or {}
+    schema_formatters = spec.get("formatters", {})
+
+    # Masking: modify values in normalized context
+    for rule in sec.get("mask", []):
+        path = rule.get("path")
+        fmt_name = rule.get("format")
+        if not path:
+            continue
+        current = deep_get(ctx, path) if "." in path else ctx.get(path)
+        if current is None:
+            continue
+        if fmt_name:
+            fmt_def = schema_formatters.get(fmt_name)
+            if fmt_def:
+                fn = FORMATTERS.get(fmt_def.get("fn"))
+                if fn:
+                    masked = fn(current, fmt_def.get("args", {}))
+                    if "." in path:
+                        deep_set(ctx, path, masked)
+                    else:
+                        ctx[path] = masked
+
+    # Redaction: remove keys entirely from normalized context
+    for path in sec.get("redact", []):
+        if "." in path:
+            deep_delete(ctx, path)
+        else:
+            if path in ctx:
+                del ctx[path]
+
+
+def resolve_item(item: Dict[str, Any], ctx: Dict[str, Any], schema_formatters: Dict[str, Dict[str, Any]]):
+    t = item.get("type")
+    if t in ("text", "kv"):
+        src = item.get("source")
+        val = ctx.get(src)
+        val = apply_format(val, item.get("format"), schema_formatters)
+        out = dict(item)
+        out["value"] = val
+        return out
+    if t == "address":
+        src = item.get("source")
+        val = ctx.get(src) or {}
+        out = dict(item)
+        out["value"] = val
+        return out
+    if t == "table":
+        src = item.get("source")
+        rows = ctx.get(src) or []
+        out = dict(item)
+        out["rows"] = rows
+        return out
+    return dict(item)
+
+
+def build_ast_from_ctx(spec: Dict[str, Any], ctx: Dict[str, Any]) -> Dict[str, Any]:
+    schema_formatters = spec.get("formatters", {}) or {}
+
+    header = spec.get("header", {}) or {}
+    ast_header = {}
+    if "left" in header:
+        ast_header["left"] = resolve_item(header["left"], ctx, schema_formatters)
+    if "right" in header:
+        ast_header["right"] = resolve_item(header["right"], ctx, schema_formatters)
+
+    ast_sections: List[Dict[str, Any]] = []
+    for sec in spec.get("sections", []):
+        items = [resolve_item(it, ctx, schema_formatters) for it in sec.get("items", [])]
+        ast_sections.append({"title": sec.get("title"), "items": items})
+
+    return {
+        "service": spec.get("service"),
+        "header": ast_header,
+        "sections": ast_sections
+    }
+
+
+def render_response_with_schema(service: Service, raw_payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Returns a renderer-agnostic AST built from the service's schema and a raw API payload.
+    Use this in both 'submit_service_form' response and 'RenderFromLogAPIView'.
+    """
+    schema = getattr(service, "schema", None)
+    if not schema or not schema.spec:
+        raise ValueError("Schema not configured for this service.")
+
+    spec = dict(schema.spec)
+    if not spec.get("service"):
+        spec["service"] = service.slug
+
+    ctx = normalize(raw_payload, spec.get("map", {}))
+    apply_security_on_ctx(ctx, spec)
+    ast = build_ast_from_ctx(spec, ctx)
+
+    return ast

--- a/backend/services/serializers.py
+++ b/backend/services/serializers.py
@@ -149,3 +149,9 @@ class ServiceUsageLogSerializer(serializers.ModelSerializer):
                 data["api_response"]["error"] = cleaned_error
 
         return data
+    
+    
+
+class RenderPreviewInputSerializer(serializers.Serializer):
+    service_slug = serializers.SlugField()
+    payload = serializers.JSONField()

--- a/backend/services/signals.py
+++ b/backend/services/signals.py
@@ -1,6 +1,7 @@
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, post_migrate
+from django.apps import apps
 from django.dispatch import receiver
-from .models import Service, HTTPStatusCode
+from .models import Service, HTTPStatusCode, RenderSchema
 from django.db import transaction
 
 @receiver(post_save, sender=Service)
@@ -13,3 +14,27 @@ def ensure_deductible_codes(sender, instance, created, **kwargs):
                 print(f"Set default deductible codes for service {instance.name}")
 
     transaction.on_commit(set_defaults)
+
+
+@receiver(post_save, sender=Service)
+def create_schema_for_service(sender, instance: Service, created, **kwargs):
+    if not created:
+        return
+    schema, _ = RenderSchema.objects.get_or_create(service=instance)
+    spec = dict(schema.spec or {})
+    spec["service"] = getattr(instance, "slug", str(instance.pk))
+    schema.spec = spec
+    schema.save(update_fields=["spec"])
+    
+@receiver(post_migrate)
+def ensure_schema_for_existing_services(sender, **kwargs):
+    ServiceModel = apps.get_model("services", "Service")
+    if ServiceModel._meta.app_label != "services":
+        return
+    for svc in ServiceModel.objects.all():
+        schema, _ = RenderSchema.objects.get_or_create(service=svc)
+        spec = dict(schema.spec or {})
+        if not spec.get("service"):
+            spec["service"] = getattr(svc, "slug", str(svc.pk))
+            schema.spec = spec
+            schema.save(update_fields=["spec"])

--- a/backend/services/urls.py
+++ b/backend/services/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ServiceCategoryDetailAPIView, ServiceCategoryListAPIView, ServiceDetailAPIView, UserServiceUsageLogListView, delete_service_pdf, generate_pdf_from_log, submit_service_form
+from .views import RenderFromLogAPIView, ServiceCategoryDetailAPIView, ServiceCategoryListAPIView, ServiceDetailAPIView, UserServiceUsageLogListView, delete_service_pdf, generate_pdf_from_log, submit_service_form
 
 urlpatterns = [
     path('categories/', ServiceCategoryListAPIView.as_view(), name='service-category-list'),
@@ -9,4 +9,5 @@ urlpatterns = [
     path("usage-logs/", UserServiceUsageLogListView.as_view(), name="user-service-usage-logs"),
     path("generate-pdf/", generate_pdf_from_log, name="generate-pdf-from-log"),
     path("delete-pdf/", delete_service_pdf, name="delete_service_pdf"),
+    path("render/", RenderFromLogAPIView.as_view(), name="services-render-from-log"),
 ]

--- a/backend/services/utils.py
+++ b/backend/services/utils.py
@@ -159,16 +159,17 @@ def render_data_recursive(p, data, x, y, indent=0, page_height=A4[1]):
                 pretty_key = prettify_key(key)
                 if is_falsy(value):
                     y = draw_bold_key_with_wrapped_value(p, x_offset, y, prettify_key(key), "Not Available", max_width=A4[0] - x_offset - 2 * cm)
-                    y -= 0.4 * cm
+                    # y -= 0.4 * cm
                 elif isinstance(value, (str, int, float, bool)) or value is None:
                     y = draw_bold_key_with_wrapped_value( p, x, y, pretty_key, value, max_width=A4[0] - (x) - 2 * cm )
-                    y -= 0.4 * cm
+                    # y -= 0.4 * cm
                 else:
-                    p.setFont("Helvetica-Bold", 14)
-                    p.drawString(x, y, f"{pretty_key}:")
+                    p.setFont("Helvetica-Bold", 13)
                     y -= 0.6 * cm
+                    p.drawString(x, y, f"{pretty_key} -")
+                    y -= 0.4 * cm
                     y = render_data_recursive(p, value, x, y, indent + 1, page_height)
-                    y -= 0.9 * cm
+                    y -= 0.6 * cm
 
     # === If it's a list ===
     elif isinstance(data, list):


### PR DESCRIPTION
- Introduced `RenderSchema` model to store rendering specifications for services.
- Added `created_at` and `updated_at` fields to `RenderSchema`.
- Implemented default specifications for rendering in `RenderSchema`.
- Created `pdf_renderer.py` for generating PDFs from rendered ASTs.
- Added `render_response_with_schema` function to build AST from service schema and payload.
- Implemented `RenderFromLogAPIView` to render service usage logs based on schema.
- Updated `generate_pdf_from_log` to utilize the new rendering logic.
- Added validation and error handling for rendering operations.
- Created utility functions for deep object manipulation and formatting.
- Updated serializers to include new rendering input structure.
- Enhanced signals to ensure schemas are created for existing services on migration.